### PR TITLE
Backend/order

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["ajuvercr <arthur.vercruysse@ugent.be>"]
 edition = "2018"
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,4 +22,4 @@ tracing-subscriber = "0.1.5"
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
 rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket", branch = "async", features = ["handlebars_templates", "tera_templates"] }
 
-rust-ini = "0.15.2"
+educe = { version = "0.4.2", features = ["Debug", "Default", "Hash", "Clone", "Copy"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,7 +19,8 @@ extern crate tracing_subscriber;
 extern crate rocket;
 extern crate rocket_contrib;
 
-extern crate ini;
+#[macro_use]
+extern crate educe;
 
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 

--- a/backend/src/planetwars/mod.rs
+++ b/backend/src/planetwars/mod.rs
@@ -8,6 +8,7 @@ use std::convert::TryInto;
 use std::fs::{create_dir, File};
 use std::io::Write;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 mod pw_config;
 mod pw_protocol;
@@ -213,11 +214,16 @@ impl game::Controller for PlanetWarsGame {
                 "name": self.name,
                 "map": self.map,
                 "file": self.log_file_loc,
+                "time": SystemTime::now(),
             }))
         } else {
             None
         }
     }
+}
+
+fn get_epoch() -> SystemTime {
+    SystemTime::UNIX_EPOCH
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -227,5 +233,7 @@ pub struct FinishedState {
     pub name: String,
     pub file: String,
     pub map: String,
+    #[serde(default = "get_epoch")]
+    pub time: SystemTime,
     pub players: Vec<(u64, String)>,
 }

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -47,7 +47,9 @@ async fn debug_get() -> Result<Template, String> {
 /// Routes the visualizer page, rendering the visualizer Template.
 #[get("/visualizer")]
 async fn visualizer_get() -> Template {
-    let game_options = get_played_games().await;
+    let mut game_options: Vec<GameState> = get_played_games().await;
+    game_options.sort();
+
     let context = Context::new_with(
         "Visualizer",
         json!({"games": game_options, "colours": COLOURS}),

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -20,7 +20,8 @@ pub static COLOURS: [&'static str; 9] = [
 
 /// The state of a player, in a running game.
 /// This represents actual players or connection keys.
-#[derive(Serialize, Eq, PartialEq)]
+#[derive(Serialize, Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord)]
 pub struct PlayerStatus {
     pub waiting: bool,
     pub connected: bool,
@@ -56,9 +57,21 @@ impl From<Connect> for PlayerStatus {
 /// The GameState is the state of a game.
 /// Either Finished, so the game is done, not running, and there is a posible visualization.
 /// Or Playing, the game is still being managed by the mozaic framework.
-#[derive(Serialize, Eq, PartialEq)]
+#[derive(Serialize, Educe)]
 #[serde(tag = "type")]
+#[educe(PartialEq, Eq, PartialOrd, Ord)]
 pub enum GameState {
+    #[educe(PartialOrd(rank = 1))]
+    Playing {
+        name: String,
+        map: String,
+        players: Vec<PlayerStatus>,
+        connected: usize,
+        total: usize,
+        #[educe(Ord(ignore), PartialOrd(ignore))]
+        state: Value,
+    },
+    #[educe(PartialOrd(rank = 2))]
     Finished {
         name: String,
         map: String,
@@ -66,36 +79,28 @@ pub enum GameState {
         turns: u64,
         file: String,
     },
-    Playing {
-        name: String,
-        map: String,
-        players: Vec<PlayerStatus>,
-        connected: usize,
-        total: usize,
-        state: Value,
-    },
 }
 
-impl PartialOrd for GameState {
-    fn partial_cmp(&self, other: &GameState) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
+// impl PartialOrd for GameState {
+//     fn partial_cmp(&self, other: &GameState) -> Option<Ordering> {
+//         Some(self.cmp(other))
+//     }
+// }
 
-impl Ord for GameState {
-    fn cmp(&self, other: &GameState) -> Ordering {
-        match self {
-            GameState::Finished { name, .. } => match other {
-                GameState::Finished { name: _name, .. } => name.cmp(_name),
-                _ => Ordering::Greater,
-            },
-            GameState::Playing { name, .. } => match other {
-                GameState::Playing { name: _name, .. } => name.cmp(_name),
-                _ => Ordering::Less,
-            },
-        }
-    }
-}
+// impl Ord for GameState {
+//     fn cmp(&self, other: &GameState) -> Ordering {
+//         match self {
+//             GameState::Finished { name, .. } => match other {
+//                 GameState::Finished { name: _name, .. } => name.cmp(_name),
+//                 _ => Ordering::Greater,
+//             },
+//             GameState::Playing { name, .. } => match other {
+//                 GameState::Playing { name: _name, .. } => name.cmp(_name),
+//                 _ => Ordering::Less,
+//             },
+//         }
+//     }
+// }
 
 impl From<FinishedState> for GameState {
     fn from(mut state: FinishedState) -> Self {

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 
 use std::cmp::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
 static NAV: [(&'static str, &'static str); 6] = [
     ("/", "Home"),
@@ -54,6 +55,10 @@ impl From<Connect> for PlayerStatus {
     }
 }
 
+fn partial_cmp(a: &SystemTime, b: &SystemTime) -> Option<Ordering> {
+    b.partial_cmp(a)
+}
+
 /// The GameState is the state of a game.
 /// Either Finished, so the game is done, not running, and there is a posible visualization.
 /// Or Playing, the game is still being managed by the mozaic framework.
@@ -63,6 +68,9 @@ impl From<Connect> for PlayerStatus {
 pub enum GameState {
     #[educe(PartialOrd(rank = 1))]
     Playing {
+        #[educe(PartialOrd(method = "partial_cmp"))]
+        time: SystemTime,
+
         name: String,
         map: String,
         players: Vec<PlayerStatus>,
@@ -73,34 +81,16 @@ pub enum GameState {
     },
     #[educe(PartialOrd(rank = 2))]
     Finished {
+        #[educe(PartialOrd(method = "partial_cmp"))]
+        time: SystemTime,
         name: String,
         map: String,
+
         players: Vec<(String, bool)>,
         turns: u64,
         file: String,
     },
 }
-
-// impl PartialOrd for GameState {
-//     fn partial_cmp(&self, other: &GameState) -> Option<Ordering> {
-//         Some(self.cmp(other))
-//     }
-// }
-
-// impl Ord for GameState {
-//     fn cmp(&self, other: &GameState) -> Ordering {
-//         match self {
-//             GameState::Finished { name, .. } => match other {
-//                 GameState::Finished { name: _name, .. } => name.cmp(_name),
-//                 _ => Ordering::Greater,
-//             },
-//             GameState::Playing { name, .. } => match other {
-//                 GameState::Playing { name: _name, .. } => name.cmp(_name),
-//                 _ => Ordering::Less,
-//             },
-//         }
-//     }
-// }
 
 impl From<FinishedState> for GameState {
     fn from(mut state: FinishedState) -> Self {
@@ -116,6 +106,7 @@ impl From<FinishedState> for GameState {
             name: state.name,
             turns: state.turns,
             file: state.file,
+            time: state.time,
         }
     }
 }
@@ -176,9 +167,9 @@ impl Context<()> {
     }
 }
 
-/// Games is the game manager wrapper so Rocket can manage it
+/// State of current live games
 pub struct Games {
-    inner: Arc<Mutex<Vec<(String, u64)>>>,
+    inner: Arc<Mutex<Vec<(String, u64, SystemTime)>>>,
 }
 
 impl Games {
@@ -189,10 +180,13 @@ impl Games {
     }
 
     pub fn add_game(&self, name: String, id: u64) {
-        self.inner.lock().unwrap().push((name, id));
+        self.inner
+            .lock()
+            .unwrap()
+            .push((name, id, SystemTime::now()));
     }
 
-    pub fn get_games(&self) -> Vec<(String, u64)> {
+    pub fn get_games(&self) -> Vec<(String, u64, SystemTime)> {
         self.inner.lock().unwrap().clone()
     }
 }


### PR DESCRIPTION
Orders everything a little better, visualiser order is fixed so that new games are displayed at the top.
This meant adding a  time field to games.ini, but is defaulted to UNIX_EPOCH.

Fixed #17 